### PR TITLE
Fix icon

### DIFF
--- a/notifications_android_tv/notifications.py
+++ b/notifications_android_tv/notifications.py
@@ -129,7 +129,7 @@ class Notifications:
         if icon:
             payload["filename"] = (
                 "image",
-                image_file,
+                icon,
                 "application/octet-stream",
                 {"Expires": "0"},
             )


### PR DESCRIPTION
Fix `icon` to allow the user to specify a separate icon in addition to `image_file`.

BTW: The default icon in bytes does not seem to render for me at least not on a fire stick. This is the default but perhaps we should remove it if it indeed displays nothing.