### PR TITLE
Remove error message logging

### DIFF
--- a/notifications_android_tv/notifications.py
+++ b/notifications_android_tv/notifications.py
@@ -59,8 +59,7 @@ class Notifications:
         try:
             requests.get(self.url, timeout=self.DEFAULT_TIMEOUT)
         except (ConnectionError, ConnectTimeout) as err:
-            _LOGGER.error("Error communicating with %s: %s", self.url, str(err))
-            raise ConnectError from err
+            raise ConnectError(err) from err
 
     def send(
         self,


### PR DESCRIPTION
Pass error message to the raised exception instead of logging it.