### PR TITLE
update MANIFEST.in, add missing file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include README.MD


### PR DESCRIPTION
```
Copying notifications_android_tv.egg-info to /var/tmp/portage/dev-python/notifications-android-tv-0.1.3/image/_python3.9/usr/lib/python3.9/site-packages/notifications_android_tv-0.1.3-py3.9.egg-info
running install_scripts
 * Using python3.9 in global scope
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install_all
Traceback (most recent call last):
  File "/usr/lib/portage/python3.9/doins.py", line 594, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/lib/portage/python3.9/doins.py", line 582, in main
    if _doins(
  File "/usr/lib/portage/python3.9/doins.py", line 434, in _doins
    return install_runner.install_file(source, os.path.dirname(dest))
  File "/usr/lib/portage/python3.9/doins.py", line 370, in install_file
    return self._ins_runner.run(source, dest_dir)
  File "/usr/lib/portage/python3.9/doins.py", line 179, in run
    sstat = os.stat(source)
FileNotFoundError: [Errno 2] No such file or directory: b'README.MD'
 * ERROR: dev-python/notifications-android-tv-0.1.3::HomeAssistantRepository failed (install phase):
 *   dodoc failed
```