### PR TITLE
Add test port function

### DIFF
--- a/notifications_android_tv/notifications.py
+++ b/notifications_android_tv/notifications.py
@@ -156,3 +156,16 @@ class Notifications:
 
 class ConnectError(Exception):
     """Exception raised for connection error."""
+
+
+def test_port(host: str, port: int = 8009) -> bool:
+    """Test if a port is open. Can be used to separate tv devices from others
+    :param host: The host to test.
+    :param port: (Optional) The port to test. Defaults to firetv DIAL
+    A valid fire stick device should have this port open
+    """
+    try:
+        requests.get(f"http://{host}:{port}")
+    except ConnectionError:
+        return False
+    return True


### PR DESCRIPTION
Many amazon devices use `amazon-` as the hostname prefix. This allows us to test amazon devices on whether they are Fire TVs/Sticks or not. We assume it is a Fire TV if port `8009` is open.