### PR TITLE
Use Enum for constants

### DIFF
--- a/notifications_android_tv/const.py
+++ b/notifications_android_tv/const.py
@@ -1,42 +1,53 @@
 """Constants for the library."""
 
+from enum import IntEnum
 from typing import Final
 
 DEFAULT_TITLE: Final = "Notification"
-DEFAULT_FONTSIZE: Final = "medium"
-DEFAULT_POSITION: Final = "bottom-left"
-DEFAULT_TRANSPARENCY: Final = "75%"
-DEFAULT_COLOR: Final = "pink"
-DEFAULT_INTERRUPT: Final = False
 DEFAULT_ICON: Final = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGP6zwAAAgcBApo"
     "cMXEAAAAASUVORK5CYII="
 )
 
-BKG_COLORS: Final = {
-    "grey": "#607d8b",
-    "black": "#000000",
-    "indigo": "#303F9F",
-    "green": "#4CAF50",
-    "red": "#F44336",
-    "cyan": "#00BCD4",
-    "teal": "#009688",
-    "amber": "#FFC107",
-    "pink": "#E91E63",
-}
-FONTSIZES: Final = {"small": 1, "medium": 0, "large": 2, "max": 3}
-POSITIONS: Final = {
-    "bottom-right": 0,
-    "bottom-left": 1,
-    "top-right": 2,
-    "top-left": 3,
-    "center": 4,
-}
 
-TRANSPARENCIES: Final = {
-    "0%": 1,
-    "25%": 2,
-    "50%": 3,
-    "75%": 4,
-    "100%": 5,
-}
+class BkgColors:
+    """Background color options."""
+
+    GREY = "#607d8b"
+    BLACK = "#000000"
+    INDIGO = "#303F9F"
+    GREEN = "#4CAF50"
+    RED = "#F44336"
+    CYAN = "#00BCD4"
+    TEAL = "#009688"
+    AMBER = "#FFC107"
+    PINK = "#E91E63"
+
+
+class FontSizes(IntEnum):
+    """Supported font sizes for notification text."""
+
+    SMALL = 1
+    MEDIUM = 0
+    LARGE = 2
+    MAX = 3
+
+
+class Positions(IntEnum):
+    """Supported positions for the notification overlay."""
+
+    BOTTOM_RIGHT = 0
+    BOTTOM_LEFT = 1
+    TOP_RIGHT = 2
+    TOP_LEFT = 3
+    CENTER = 4
+
+
+class Transparencies(IntEnum):
+    """Supported transparencies for the notification overlay."""
+
+    _0_PERCENT = 1
+    _25_PERCENT = 2
+    _50_PERCENT = 3
+    _75_PERCENT = 4
+    _100_PERCENT = 5


### PR DESCRIPTION
## Proposed changes

- Use Enum for constants
- Clean up async_send function to better handle optinal parameters.