### PR TITLE
Remove httpx version constrains

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-httpx = "^0.27.0"
+httpx = "^0.27"
 
 [tool.poetry.group.dev.dependencies]
 colorlog = "^6.6.0"


### PR DESCRIPTION
httpx version is currently constrained to >=0.27.0,<0.28.0. Home Assistant uses httpx 0.28.1, which prevents bumping this library to the current version